### PR TITLE
chore: fix exists

### DIFF
--- a/backends/cache_s3
+++ b/backends/cache_s3
@@ -16,7 +16,7 @@ build_key() {
 restore_cache() {
   local from="$1"
   local to="$2"
-  aws s3 sync "s3://${BUILDKITE_PLUGIN_S3_CACHE_BUCKET}/$(build_key "${from}")" "${to}" 
+  aws s3 sync "s3://${BUILDKITE_PLUGIN_S3_CACHE_BUCKET}/$(build_key "${from}")" "${to}"
 }
 
 save_cache() {
@@ -27,7 +27,7 @@ save_cache() {
 
 exists_cache() {
   if [ -z "$1" ]; then exit 1; fi
-  [ ! -z "$(aws s3api list-objects-v2 --bucket "${BUILDKITE_PLUGIN_S3_CACHE_BUCKET}" --prefix "$(build_key "$1")" --max-items 1)" ]
+  [ -n "$(aws s3api list-objects-v2 --bucket "${BUILDKITE_PLUGIN_S3_CACHE_BUCKET}" --prefix "$(build_key "$1")" --max-items 1)" ]
 }
 
 OPCODE="$1"

--- a/backends/cache_s3
+++ b/backends/cache_s3
@@ -14,7 +14,7 @@ build_key() {
 }
 
 restore_cache() {
-  local from=$1
+  local from="$1"
   local to="$2"
   aws s3 sync "s3://${BUILDKITE_PLUGIN_S3_CACHE_BUCKET}/$(build_key "${from}")" "${to}" 
 }
@@ -27,7 +27,7 @@ save_cache() {
 
 exists_cache() {
   if [ -z "$1" ]; then exit 1; fi
-  aws s3api list-objects-v2 --bucket "${BUILDKITE_PLUGIN_S3_CACHE_BUCKET}" --prefix "$(build_key "$1")" --max-items 1
+  [ ! -z "$(aws s3api list-objects-v2 --bucket "${BUILDKITE_PLUGIN_S3_CACHE_BUCKET}" --prefix "$(build_key "$1")" --max-items 1)" ]
 }
 
 OPCODE="$1"

--- a/tests/cache_s3.bats
+++ b/tests/cache_s3.bats
@@ -48,7 +48,7 @@ setup() {
 }
 
 @test 'Exists on existing file/folder works' {
-  stub aws 'exit 0'
+  stub aws 'echo "exists"'
 
   run "${PWD}/backends/cache_s3" exists existing
 
@@ -62,11 +62,11 @@ setup() {
   touch "${BATS_TEST_TMPDIR}/new-file"
   mkdir "${BATS_TEST_TMPDIR}/s3-cache"
   stub aws \
-    "test -e $BATS_TEST_TMPDIR/s3-cache/\$(echo s3://\$4/\$6 | md5sum | cut -c-32)" \
+    "echo" \
     "ln -s \$3 $BATS_TEST_TMPDIR/s3-cache/\$(echo \$4 | md5sum | cut -c-32)" \
-    "test -e $BATS_TEST_TMPDIR/s3-cache/\$(echo s3://\$4/\$6 | md5sum | cut -c-32)" \
+    "echo 'exists'" \
     "cp -r $BATS_TEST_TMPDIR/s3-cache/\$(echo \$3 | md5sum | cut -c-32) \$4"
-    
+
   run "${PWD}/backends/cache_s3" exists new-file
 
   assert_failure
@@ -100,13 +100,13 @@ setup() {
   echo 'random content' > "${BATS_TEST_TMPDIR}/new-folder/new-file"
 
   stub aws \
-    "test -e $BATS_TEST_TMPDIR/s3-cache/\$(echo s3://\$4/\$6 | md5sum | cut -c-32)" \
+    "echo" \
     "ln -s \$3 $BATS_TEST_TMPDIR/s3-cache/\$(echo \$4 | md5sum | cut -c-32)" \
-    "test -e $BATS_TEST_TMPDIR/s3-cache/\$(echo s3://\$4/\$6 | md5sum | cut -c-32)" \
+    "echo 'exists'" \
     "cp -r $BATS_TEST_TMPDIR/s3-cache/\$(echo \$3 | md5sum | cut -c-32) \$4"
 
   run "${PWD}/backends/cache_s3" exists new-folder
-  
+
   assert_failure
   assert_output ''
 


### PR DESCRIPTION
`aws s3api list-objects-v2` doesn't return an error code if the file is missing, just an empty response (with exit code 0).