### PR TITLE
FS backend recursive saves

### DIFF
--- a/backends/cache_fs
+++ b/backends/cache_fs
@@ -12,7 +12,7 @@ save_cache() {
   local to="${CACHE_FOLDER}/$1"
   local from="$2"
 
-  if [ -n "$1" ] && [ -e "${from}" ]; then
+  if [ -n "$1" ] && [ -e "$to" ]; then
     rm -rf "$to"
   fi
   cp -a "$from" "$to"

--- a/backends/cache_fs
+++ b/backends/cache_fs
@@ -11,6 +11,10 @@ restore_cache() {
 save_cache() {
   local to="${CACHE_FOLDER}/$1"
   local from="$2"
+
+  if [ -n "$1" ] && [ -e "${from}" ]; then
+    rm -rf "$to"
+  fi
   cp -a "$from" "$to"
 }
 


### PR DESCRIPTION
Corrects a bug in the FS backend when a cache key is saved multiple times. Before this change, the cached folder would be copied inside the existing one instead of overwriting it.