### PR TITLE
FS backend race condition

### DIFF
--- a/backends/cache_fs
+++ b/backends/cache_fs
@@ -1,21 +1,40 @@
 #!/bin/bash
+set -euo pipefail
 
 CACHE_FOLDER="${BUILDKITE_PLUGIN_FS_CACHE_FOLDER:-/var/cache/buildkite}"
+
+DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
+
+# shellcheck source=lib/lock.bash
+. "${DIR}/../lib/lock.bash"
 
 restore_cache() {
   local from="${CACHE_FOLDER}/$1"
   local to="$2"
+
+  wait_and_lock "${from}"
+  # shellcheck disable=2064  # actually want variable interpolated here
+  trap "release_lock_folder '${from}'" SIGINT SIGTERM SIGQUIT
+
   cp -a "$from" "$to"
+
+  release_lock "${from}"
 }
 
 save_cache() {
   local to="${CACHE_FOLDER}/$1"
   local from="$2"
 
+  wait_and_lock "${to}"
+  # shellcheck disable=2064  # actually want variable interpolated here
+  trap "release_lock '${to}'" SIGINT SIGTERM SIGQUIT
+
   if [ -n "$1" ] && [ -e "$to" ]; then
     rm -rf "$to"
   fi
   cp -a "$from" "$to"
+
+  release_lock "${to}"
 }
 
 exists_cache() {

--- a/lib/lock.bash
+++ b/lib/lock.bash
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -euo pipefail
+
+lock () {
+  local folder="${1}.lock"
+  (
+    set -o noclobber
+    date > "${folder}"
+  ) 2>/dev/null
+}
+
+wait_and_lock () {
+  local folder="${1}.lock"
+  local max_attempts="${2:-5}"
+
+  for ATTEMPT in $(seq 1 "${max_attempts}"); do
+    if ! lock "${folder}"; then
+      echo 'Waiting for folder lock'
+      sleep "${ATTEMPT}"
+    else
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+release_lock () {
+  local folder="${1}.lock"
+  rm -f "${folder}"
+}

--- a/lib/lock.bash
+++ b/lib/lock.bash
@@ -2,19 +2,19 @@
 set -euo pipefail
 
 lock () {
-  local folder="${1}.lock"
+  local file="${1}.lock"
   (
     set -o noclobber
-    date > "${folder}"
+    date > "${file}"
   ) 2>/dev/null
 }
 
 wait_and_lock () {
-  local folder="${1}.lock"
+  local file="${1}.lock"
   local max_attempts="${2:-5}"
 
   for ATTEMPT in $(seq 1 "${max_attempts}"); do
-    if ! lock "${folder}"; then
+    if ! lock "${1}"; then
       echo 'Waiting for folder lock'
       sleep "${ATTEMPT}"
     else
@@ -26,6 +26,6 @@ wait_and_lock () {
 }
 
 release_lock () {
-  local folder="${1}.lock"
-  rm -f "${folder}"
+  local file="${1}.lock"
+  rm -f "${file}"
 }

--- a/tests/lock.bats
+++ b/tests/lock.bats
@@ -1,0 +1,52 @@
+#!/usr/bin/env bats
+
+setup() {
+  load "${BATS_PLUGIN_PATH}/load.bash"
+  
+  source "${PWD}/lib/lock.bash"
+}
+
+@test 'basic locking works as expected' {
+  LOCKFILE="${BATS_TEST_TMPDIR}/lock.file"
+
+  run lock "${LOCKFILE}"
+  assert_success
+  assert_output ''
+
+  run lock "${LOCKFILE}"
+  assert_failure
+  assert_output ''
+
+  run release_lock "${LOCKFILE}"
+  assert_success
+  assert_output ''
+
+  run lock "${LOCKFILE}"
+  assert_success
+  assert_output ''
+
+  rm -f "${LOCKFILE}"
+}
+
+
+@test 'lock times out' {
+  LOCKFILE="${BATS_TEST_TMPDIR}/lock.file"
+
+  run wait_and_lock "${LOCKFILE}"
+  assert_success
+  assert_output ''
+  
+  run wait_and_lock "${LOCKFILE}" 1
+  assert_failure
+  assert_equal "$(echo "${output}" | wc -l)" "1"
+
+  run wait_and_lock "${LOCKFILE}"
+  assert_failure
+  assert_equal "$(echo "${output}" | wc -l)" "5"
+
+  run release_lock "${LOCKFILE}"
+  assert_success
+  assert_output ''
+
+  rm -f "${LOCKFILE}"
+}


### PR DESCRIPTION
There is an issue with the FS backend when a cache entry is being restored and saved at the same time. After #41, this causes the restoration to fail if files are deleted from under its feet.

I researched locking but decided on something [bash-only based on a more complex example](https://stackoverflow.com/a/31955862/1352026) that does not add any dependencies. It may affect performance when more than one operation is happening at the same time, but at least avoid failing the step due to this bug.

Eventually I would like to make a better implementation of this that at least allows for concurrent reads at least.