### PR TITLE
Try to fix S3 sync by using a temporary directory for `tgz` archiving

### DIFF
--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -30,7 +30,7 @@ fi
 
 build_key "${MAX_LEVEL}" "${RESTORE_PATH}" >/dev/null # to validate the level
 
-ACTUAL_PATH=$(mktemp)
+ACTUAL_PATH=$(mktemp -d)
 
 if [ "${COMPRESS}" = 'tgz' ]; then
   UNCOMPRESS_COMMAND=(tar xzf)
@@ -50,11 +50,11 @@ for CURRENT_LEVEL in "${SORTED_LEVELS[@]}"; do
   KEY=$(build_key "${CURRENT_LEVEL}" "${RESTORE_PATH}" "${COMPRESS}")
   if backend_exec exists "${KEY}"; then
     echo "Cache hit at ${CURRENT_LEVEL} level, restoring ${RESTORE_PATH}..."
-    backend_exec get "${KEY}" "${ACTUAL_PATH}"
+    backend_exec get "${KEY}" "${ACTUAL_PATH}/${KEY}.tgz"
 
     if [ "${COMPRESS}" != 'none' ]; then
       echo "Cache is compressed, uncompressing..."
-      "${UNCOMPRESS_COMMAND[@]}" "${ACTUAL_PATH}" "${RESTORE_PATH}"
+      "${UNCOMPRESS_COMMAND[@]}" "${ACTUAL_PATH}/${KEY}.tgz" "${RESTORE_PATH}"
     fi
 
     exit 0

--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -50,11 +50,11 @@ for CURRENT_LEVEL in "${SORTED_LEVELS[@]}"; do
   KEY=$(build_key "${CURRENT_LEVEL}" "${RESTORE_PATH}" "${COMPRESS}")
   if backend_exec exists "${KEY}"; then
     echo "Cache hit at ${CURRENT_LEVEL} level, restoring ${RESTORE_PATH}..."
-    backend_exec get "${KEY}" "${ACTUAL_PATH}/${KEY}.tgz"
+    backend_exec get "${KEY}" "${ACTUAL_PATH}"
 
     if [ "${COMPRESS}" != 'none' ]; then
       echo "Cache is compressed, uncompressing..."
-      "${UNCOMPRESS_COMMAND[@]}" "${ACTUAL_PATH}/${KEY}.tgz" "${RESTORE_PATH}"
+      "${UNCOMPRESS_COMMAND[@]}" "${ACTUAL_PATH}/archive.tgz" "${RESTORE_PATH}"
     fi
 
     exit 0

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -38,8 +38,8 @@ fi
 
 if [ "${COMPRESS}" != 'none' ]; then
   echo "Compressing ${CACHE_PATH} with ${COMPRESS}..."
-  ACTUAL_PATH=$(mktemp)
-  "${COMPRESS_COMMAND[@]}" "${ACTUAL_PATH}" "${CACHE_PATH}"
+  ACTUAL_PATH=$(mktemp -d)
+  "${COMPRESS_COMMAND[@]}" "${ACTUAL_PATH}/${KEY}.tgz" "${CACHE_PATH}"
 else
   ACTUAL_PATH="${CACHE_PATH}"
 fi

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -39,7 +39,7 @@ fi
 if [ "${COMPRESS}" != 'none' ]; then
   echo "Compressing ${CACHE_PATH} with ${COMPRESS}..."
   ACTUAL_PATH=$(mktemp -d)
-  "${COMPRESS_COMMAND[@]}" "${ACTUAL_PATH}/${KEY}.tgz" "${CACHE_PATH}"
+  "${COMPRESS_COMMAND[@]}" "${ACTUAL_PATH}/archive.tgz" "${CACHE_PATH}"
 else
   ACTUAL_PATH="${CACHE_PATH}"
 fi


### PR DESCRIPTION
Fixes #52.

This fixes the `s3 sync` problem when using compression, by using a temporary directory, rather than trying to archive a single file with `sync`.