### PR TITLE
Use 'env bash' in hook shebang rather than 'bash'

### DIFF
--- a/backends/cache_fs
+++ b/backends/cache_fs
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 CACHE_FOLDER="${BUILDKITE_PLUGIN_FS_CACHE_FOLDER:-/var/cache/buildkite}"

--- a/backends/cache_s3
+++ b/backends/cache_s3
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ -z "${BUILDKITE_PLUGIN_S3_CACHE_BUCKET}" ]; then
   echo '+++ 🚨 Missing S3 bucket configuration'

--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"

--- a/lib/lock.bash
+++ b/lib/lock.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 lock () {

--- a/lib/plugin.bash
+++ b/lib/plugin.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 PLUGIN_PREFIX="CACHE"

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 


### PR DESCRIPTION
We use a custom buildkite runner for which the location of `bash` is not `/bin/bash`.

Changing this shebang would make this a bit more portable to custom agents. `/usr/bin/env` exists on the official buildkite agent, so this should have no impact on users running the standard workflow.