### PR TITLE
Correct usage of `list-object-v2`

### DIFF
--- a/backends/cache_s3
+++ b/backends/cache_s3
@@ -33,13 +33,14 @@ s3_sync() {
 s3_listobjects() {
   local prefix="$1"
 
-  aws_cmd=(aws s3api list-objects-v2 --bucket "${BUILDKITE_PLUGIN_S3_CACHE_BUCKET}" --prefix "$(build_key "${prefix}")" --max-items 1)
+  aws_cmd=(aws s3api list-objects-v2 --bucket "${BUILDKITE_PLUGIN_S3_CACHE_BUCKET}" --prefix "$(build_key "${prefix}")" --max-items 1 --query Contents)
 
   if [ -n "${BUILDKITE_PLUGIN_S3_CACHE_ENDPOINT}" ]; then
     aws_cmd+=(--endpoint-url "${BUILDKITE_PLUGIN_S3_CACHE_ENDPOINT}")
   fi
 
-  "${aws_cmd[@]}"
+  result=$("${aws_cmd[@]}")
+  [ "${result}" != 'null' ]
 }
 
 restore_cache() {
@@ -56,7 +57,7 @@ save_cache() {
 
 exists_cache() {
   if [ -z "$1" ]; then exit 1; fi
-  [ -n "$(s3_listobjects "$1")" ]
+  s3_listobjects "$1"
 }
 
 OPCODE="$1"

--- a/tests/cache_s3.bats
+++ b/tests/cache_s3.bats
@@ -37,7 +37,7 @@ setup() {
 }
 
 @test 'Exists on non-existing file fails' {
-  stub aws 'exit 1'
+  stub aws 'echo null'
 
   run "${PWD}/backends/cache_s3" exists PATH/THAT/DOES/NOT/EXIST
 
@@ -97,10 +97,10 @@ setup() {
   stub aws \
     's3 sync --endpoint-url https://s3.somewhere.com \* \* : echo ' \
     's3 sync --endpoint-url https://s3.somewhere.com \* \* : echo ' \
-    's3api list-objects-v2 --bucket \* --prefix \* --max-items 1 --endpoint-url https://s3.somewhere.com : echo exists' \
+    's3api list-objects-v2 --bucket \* --prefix \* --max-items 1  --query Contents --endpoint-url https://s3.somewhere.com : echo exists' \
     's3 sync \* \* : echo ' \
     's3 sync \* \* : echo ' \
-    's3api list-objects-v2 --bucket \* --prefix \* --max-items 1 : echo exists'
+    's3api list-objects-v2 --bucket \* --prefix \* --max-items 1 --query Contents : echo exists'
 
   run "${PWD}/backends/cache_s3" save from to
 
@@ -141,7 +141,7 @@ setup() {
   touch "${BATS_TEST_TMPDIR}/new-file"
   mkdir "${BATS_TEST_TMPDIR}/s3-cache"
   stub aws \
-    "echo" \
+    "echo null" \
     "ln -s \$3 $BATS_TEST_TMPDIR/s3-cache/\$(echo \$4 | md5sum | cut -c-32)" \
     "echo 'exists'" \
     "cp -r $BATS_TEST_TMPDIR/s3-cache/\$(echo \$3 | md5sum | cut -c-32) \$4"
@@ -179,7 +179,7 @@ setup() {
   echo 'random content' > "${BATS_TEST_TMPDIR}/new-folder/new-file"
 
   stub aws \
-    "echo" \
+    "echo null" \
     "ln -s \$3 $BATS_TEST_TMPDIR/s3-cache/\$(echo \$4 | md5sum | cut -c-32)" \
     "echo 'exists'" \
     "cp -r $BATS_TEST_TMPDIR/s3-cache/\$(echo \$3 | md5sum | cut -c-32) \$4"


### PR DESCRIPTION
As mentioned in #55 there was an issue with the usage of `list-object-v2`. Basically, when making the call to a non-existing object, the command would not fail, just return a response that has no content.

But it would appear to have been something changed in the responses of the AWS API call as I could duplicate the issue when using v1.32.65 as well so I have updated the call and logic [based on their fix](https://github.com/opzkit/cache-buildkite-plugin/commit/90c74a0722475193fabd98ddd515b0e4dda85e1b) as well as updated the corresponding tests.

Closes #55 