### PR TITLE
Corrected use of sync/cp

### DIFF
--- a/backends/cache_s3
+++ b/backends/cache_s3
@@ -13,49 +13,63 @@ build_key() {
   fi
 }
 
-s3_cmd() {
-  local from="$1"
-  local to="$2"
-  local use_sync="${3:-true}"
-
-  aws_cmd=(aws s3)
-
-  if [ "${use_sync}" = 'true' ]; then
-    aws_cmd+=(sync)
-  else
-    aws_cmd+=(cp)
-  fi
-
-  if [ -n "${BUILDKITE_PLUGIN_S3_CACHE_ONLY_SHOW_ERRORS}" ]; then
-    aws_cmd+=(--only-show-errors)
-  fi
+aws_cmd() {
+  aws_cmd=(aws)
 
   if [ -n "${BUILDKITE_PLUGIN_S3_CACHE_ENDPOINT}" ]; then
     aws_cmd+=(--endpoint-url "${BUILDKITE_PLUGIN_S3_CACHE_ENDPOINT}")
   fi
 
-  "${aws_cmd[@]}" "${from}" "${to}"
+  "${aws_cmd[@]}" "$@"
+}
+
+s3_copy() {
+  local from="$1"
+  local to="$2"
+  local use_sync="${3:-true}"
+  local options=()
+
+  if [ "${use_sync}" = 'true' ]; then
+    options+=(sync)
+  else
+    options+=(cp)
+  fi
+
+  if [ -n "${BUILDKITE_PLUGIN_S3_CACHE_ONLY_SHOW_ERRORS}" ]; then
+    options+=(--only-show-errors)
+  fi
+
+  aws_cmd s3 "${options[@]}" "${from}" "${to}"
 }
 
 s3_listobjects() {
   local prefix="$1"
 
-  aws_cmd=(aws s3api list-objects-v2 --bucket "${BUILDKITE_PLUGIN_S3_CACHE_BUCKET}" --prefix "$(build_key "${prefix}")" --max-items 1 --query Contents)
+  result="$(
+    aws_cmd s3api list-objects-v2 \
+      --bucket "${BUILDKITE_PLUGIN_S3_CACHE_BUCKET}" \
+      --prefix "$(build_key "${prefix}")" \
+      --max-items 1 \
+      --query Contents
+  )"
 
-  if [ -n "${BUILDKITE_PLUGIN_S3_CACHE_ENDPOINT}" ]; then
-    aws_cmd+=(--endpoint-url "${BUILDKITE_PLUGIN_S3_CACHE_ENDPOINT}")
-  fi
-
-  result=$("${aws_cmd[@]}")
   [ "${result}" != 'null' ]
 }
 
 restore_cache() {
   local from="$1"
   local to="$2"
+  local sync='false'
+
+  key="$(build_key "${from}")"
+
+  # if the object does not exist, assume it is a folder so use sync
+  if ! aws_cmd s3api head-object --bucket "${BUILDKITE_PLUGIN_S3_CACHE_BUCKET}" --key "${key}"; then
+    sync=true
+  fi
 
   # can not use sync as it may be a single file
-  s3_cmd "s3://${BUILDKITE_PLUGIN_S3_CACHE_BUCKET}/$(build_key "${from}")" "${to}"
+  s3_copy "s3://${BUILDKITE_PLUGIN_S3_CACHE_BUCKET}/${key}" "${to}" "${sync}"
 }
 
 save_cache() {
@@ -66,7 +80,7 @@ save_cache() {
     use_sync='false'
   fi
 
-  s3_cmd "${from}" "s3://${BUILDKITE_PLUGIN_S3_CACHE_BUCKET}/$(build_key "${to}")" "${use_sync}"
+  s3_copy "${from}" "s3://${BUILDKITE_PLUGIN_S3_CACHE_BUCKET}/$(build_key "${to}")" "${use_sync}"
 }
 
 exists_cache() {

--- a/backends/cache_s3
+++ b/backends/cache_s3
@@ -16,14 +16,14 @@ build_key() {
 s3_cmd() {
   local from="$1"
   local to="$2"
-  local use_sync="${3:-1}"
+  local use_sync="${3:-true}"
 
   aws_cmd=(aws s3)
 
   if [ "${use_sync}" = 'true' ]; then
     aws_cmd+=(sync)
   else
-    aws_cmd+=(cp --recursive)
+    aws_cmd+=(cp)
   fi
 
   if [ -n "${BUILDKITE_PLUGIN_S3_CACHE_ONLY_SHOW_ERRORS}" ]; then
@@ -55,7 +55,7 @@ restore_cache() {
   local to="$2"
 
   # can not use sync as it may be a single file
-  s3_cmd "s3://${BUILDKITE_PLUGIN_S3_CACHE_BUCKET}/$(build_key "${from}")" "${to}" 'false'
+  s3_cmd "s3://${BUILDKITE_PLUGIN_S3_CACHE_BUCKET}/$(build_key "${from}")" "${to}"
 }
 
 save_cache() {
@@ -66,7 +66,7 @@ save_cache() {
     use_sync='false'
   fi
 
-  s3_cmd "${from}" "s3://${BUILDKITE_PLUGIN_S3_CACHE_BUCKET}/$(build_key "${to}")"
+  s3_cmd "${from}" "s3://${BUILDKITE_PLUGIN_S3_CACHE_BUCKET}/$(build_key "${to}")" "${use_sync}"
 }
 
 exists_cache() {

--- a/tests/cache_s3.bats
+++ b/tests/cache_s3.bats
@@ -61,10 +61,10 @@ setup() {
 @test 'Verbose flag passed when environment is set' {
   export BUILDKITE_PLUGIN_S3_CACHE_ONLY_SHOW_ERRORS=1
   stub aws \
-    's3 cp --recursive --only-show-errors \* \* : echo ' \
-    's3 cp --recursive --only-show-errors \* \* : echo ' \
-    's3 cp --recursive \* \* : echo ' \
-    's3 cp --recursive \* \* : echo '
+    's3 sync --only-show-errors \* \* : echo ' \
+    's3 sync --only-show-errors \* \* : echo ' \
+    's3 sync \* \* : echo ' \
+    's3 sync \* \* : echo '
 
   run "${PWD}/backends/cache_s3" save from to
 
@@ -95,11 +95,11 @@ setup() {
   export BUILDKITE_PLUGIN_S3_CACHE_ENDPOINT=https://s3.somewhere.com
 
   stub aws \
-    's3 cp --recursive --endpoint-url https://s3.somewhere.com \* \* : echo ' \
-    's3 cp --recursive --endpoint-url https://s3.somewhere.com \* \* : echo ' \
+    's3 sync --endpoint-url https://s3.somewhere.com \* \* : echo ' \
+    's3 sync --endpoint-url https://s3.somewhere.com \* \* : echo ' \
     's3api list-objects-v2 --bucket \* --prefix \* --max-items 1 --query Contents --endpoint-url https://s3.somewhere.com : echo exists' \
-    's3 cp --recursive \* \* : echo ' \
-    's3 cp --recursive \* \* : echo ' \
+    's3 sync \* \* : echo ' \
+    's3 sync \* \* : echo ' \
     's3api list-objects-v2 --bucket \* --prefix \* --max-items 1 --query Contents : echo exists'
 
   run "${PWD}/backends/cache_s3" save from to
@@ -142,9 +142,9 @@ setup() {
   mkdir "${BATS_TEST_TMPDIR}/s3-cache"
   stub aws \
     "echo null" \
-    "ln -s \$4 $BATS_TEST_TMPDIR/s3-cache/\$(echo \$5 | md5sum | cut -c-32)" \
+    "s3 cp \* \* : ln -s \$3 $BATS_TEST_TMPDIR/s3-cache/\$(echo \$4 | md5sum | cut -c-32)" \
     "echo 'exists'" \
-    "cp -r $BATS_TEST_TMPDIR/s3-cache/\$(echo \$4 | md5sum | cut -c-32) \$5"
+    "s3 sync \* \* : cp -r $BATS_TEST_TMPDIR/s3-cache/\$(echo \$3 | md5sum | cut -c-32) \$4"
 
   run "${PWD}/backends/cache_s3" exists new-file
 
@@ -180,9 +180,9 @@ setup() {
 
   stub aws \
     "echo null" \
-    "ln -s \$4 $BATS_TEST_TMPDIR/s3-cache/\$(echo \$5 | md5sum | cut -c-32)" \
+    "s3 sync \* \* : ln -s \$3 $BATS_TEST_TMPDIR/s3-cache/\$(echo \$4 | md5sum | cut -c-32)" \
     "echo 'exists'" \
-    "cp -r $BATS_TEST_TMPDIR/s3-cache/\$(echo \$4 | md5sum | cut -c-32) \$5"
+    "s3 sync \* \* : cp -r $BATS_TEST_TMPDIR/s3-cache/\$(echo \$3 | md5sum | cut -c-32) \$4"
 
   run "${PWD}/backends/cache_s3" exists new-folder
 


### PR DESCRIPTION
Apparently the logic was all twisted up in #62 as the issues were still appearing.

My tests indicate that `aws s3 sync A s3://bucket/B` and `aws s3 cp --recursive A s3://bucket/B` will fail if `A` is a single file so I removed the `--recursive` from the usage of `cp` to have that scenario work. On cache restores, `sync` works both with single files as well as folders... but only if `.` is the destination. So I re-worked the logic to check if trying to recover a single file to use `cp` instead of `sync`.

While at it, I noticed that some aws calls were not honoring the endpoint URL option so I refactored AWS calls to encapsulate all those global options.