### PR TITLE
target hosted queue

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,9 +1,13 @@
 steps:
   - label: ":shell: Tests"
+    agents:
+      queue: "hosted"
     plugins:
       - plugin-tester#v1.1.1: ~
 
   - label: ":shell: Shellcheck"
+    agents:
+      queue: "hosted"
     plugins:
       - shellcheck#v1.3.0:
           files:
@@ -13,6 +17,8 @@ steps:
           options: "-x"
 
   - label: ":sparkles: Lint"
+    agents:
+      queue: "hosted"
     plugins:
       - plugin-linter#v3.3.0:
           id: cache


### PR DESCRIPTION
The default queue in this cluster is `untrusted`, but we're trialing a new queue: `hosted`. The agents on this queue are configured differently, but I expect everything to Just Work.