### PR TITLE
Avoid duplicate save

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,9 @@ steps:
           manifest: package-lock.json
           path: node_modules
           restore: pipeline
-          save: file
+          save:
+            - file
+            - branch
   - wait: ~
   - label: ':test_tube: Run tests'
     command: npm test # does not save cache, not necessary

--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ Assuming the underlying executables are available, the allowed values are:
 * `tgz`: `tar` with gzip compression
 * `zip`: `(un)zip` compression
 
+### `force` (boolean, optional, save only)
+
+Force saving the cache even if it exists. Default: `false`.
+
 ### `manifest` (string, required if using `file` caching level)
 
 A path to a file or folder that will be hashed to create file-level caches.

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -49,6 +49,11 @@ fi
 for LEVEL in "${SAVE_LEVELS[@]}"; do
   KEY=$(build_key "${LEVEL}" "${CACHE_PATH}" "${COMPRESS}")
 
-  echo "Saving ${LEVEL}-level cache of ${CACHE_PATH}"
-  backend_exec save "${KEY}" "${ACTUAL_PATH}"
+  if [ "$(plugin_read_config FORCE 'false')" != 'false' ] ||
+     ! backend_exec exists "${KEY}"; then
+    echo "Saving ${LEVEL}-level cache of ${CACHE_PATH}"
+    backend_exec save "${KEY}" "${ACTUAL_PATH}"
+  else
+    echo "Cache of ${LEVEL} already exists, skipping"
+  fi
 done

--- a/plugin.yml
+++ b/plugin.yml
@@ -21,6 +21,8 @@ configuration:
         - zip
         - tar
         - tgz
+    force:
+      type: boolean
     manifest:
       type: string
     path:

--- a/tests/post-command-tgz.bats
+++ b/tests/post-command-tgz.bats
@@ -15,6 +15,9 @@ setup() {
   export BUILDKITE_PLUGIN_CACHE_COMPRESSION=tgz
   export BUILDKITE_PLUGIN_CACHE_PATH=tests/data/my_files
 
+  # to make all test easier
+  export BUILDKITE_PLUGIN_CACHE_FORCE=true
+
   # necessary for key-calculations
   export BUILDKITE_LABEL="step-label"
   export BUILDKITE_BRANCH="tests"

--- a/tests/post-command-zip.bats
+++ b/tests/post-command-zip.bats
@@ -15,6 +15,9 @@ setup() {
   export BUILDKITE_PLUGIN_CACHE_COMPRESSION=zip
   export BUILDKITE_PLUGIN_CACHE_PATH=tests/data/my_files
 
+  # to make all test easier
+  export BUILDKITE_PLUGIN_CACHE_FORCE=true
+
   # necessary for key-calculations
   export BUILDKITE_LABEL="step-label"
   export BUILDKITE_BRANCH="tests"

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -13,6 +13,9 @@ setup() {
   export BUILDKITE_PLUGIN_CACHE_BACKEND=dummy
   export BUILDKITE_PLUGIN_CACHE_PATH=tests/data/my_files
 
+  # to make all test easier
+  export BUILDKITE_PLUGIN_CACHE_FORCE=true
+
   # necessary for key-calculations
   export BUILDKITE_LABEL="step-label"
   export BUILDKITE_BRANCH="tests"
@@ -178,4 +181,19 @@ teardown() {
 
   assert_output --partial 'Invalid cache level unreal'
   refute_output --partial 'Saving pipeline-level cache'
+}
+
+@test "Saving is skipped when cache exists" {
+  export BUILDKITE_PLUGIN_CACHE_SAVE=all
+  export BUILDKITE_PLUGIN_CACHE_FORCE='false'
+
+  stub cache_dummy \
+    "exists \* \* : exit 0"
+
+  run "$PWD/hooks/post-command"
+
+  assert_success
+  refute_output --partial 'Saving all-level cache'
+
+  unstub cache_dummy
 }


### PR DESCRIPTION
(building on top of #75 which should be merged first)

Before saving a cache entry, if it already exists and the new `force` option is turned off (the default), it will not be saved again. This should help speed up builds even further - which is the main purpose of the cache plugin in the first place.

Closes #72