### PR TITLE
abort post-command on non-zero exit status

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -1,6 +1,12 @@
 #!/bin/bash
 set -euo pipefail
 
+# skip caching if command exited non-zero
+if [ $BUILDKITE_COMMAND_EXIT_STATUS -ne 0 ] ; then
+  echo "Aborting cache post-command hook because command exited with status $BUILDKITE_COMMAND_EXIT_STATUS"
+  exit 1
+fi
+
 DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 
 # shellcheck source=lib/shared.bash


### PR DESCRIPTION
resolves #80
if the command (eg, bundle install) fails partway through, the cache plugin could upload a poisoned cache