### PR TITLE
Allow restoring directories

### DIFF
--- a/backends/cache_fs
+++ b/backends/cache_fs
@@ -22,6 +22,9 @@ restore_cache() {
   # shellcheck disable=2064  # actually want variable interpolated here
   trap "release_lock_folder '${from}'" SIGINT SIGTERM SIGQUIT
 
+  if [ -n "$1" ] && [ -e "$to" ]; then
+    rm -rf "$to"
+  fi
   cp -a "$from" "$to"
 
   release_lock "${from}"


### PR DESCRIPTION
Removes the target file (or folder) before starting the restore.

Without this step, if you are restoring a folder, it will create a folder under it

For example, let's say cache is `/var/cache/buildkite/978d7c5ebf8d670814180efd0e18ca4745059acd` and we want to restore `/go`.

If the `/go` already exists, `cp -a "$from" "$to"` will create the folder `978d7c5ebf8d670814180efd0e18ca4745059acd` under the `/go` folder, instead of copying it as it.

By removing the folder prior we ensure the logic is the same for folder and files.