### PR TITLE
Allow restoring directories

### DIFF
--- a/backends/cache_fs
+++ b/backends/cache_fs
@@ -22,7 +22,11 @@ restore_cache() {
   # shellcheck disable=2064  # actually want variable interpolated here
   trap "release_lock_folder '${from}'" SIGINT SIGTERM SIGQUIT
 
-  cp -a "$from" "$to"
+  if [ -d "$from" ]; then
+    cp -a "${from}/." "$to" # copy as folder
+  else
+    cp -a "$from" "$to"
+  fi
 
   release_lock "${from}"
 }


### PR DESCRIPTION
If the target is a folder and it already exists, a `cp` will not copy the folder correctly.

For example, let's say the cache is `/var/cache/buildkite/978d7c5ebf8d670814180efd0e18ca4745059acd` and we want to restore `/go`.

If the `/go` already exists, `cp -a "$from" "$to"` will create the folder `978d7c5ebf8d670814180efd0e18ca4745059acd` under the `/go` folder instead of copying it as it.

This PR fixes this issue.