### PR TITLE
Enables 'rsync' as a copy tool

### DIFF
--- a/backends/cache_fs
+++ b/backends/cache_fs
@@ -22,7 +22,11 @@ restore_cache() {
   # shellcheck disable=2064  # actually want variable interpolated here
   trap "release_lock_folder '${from}'" SIGINT SIGTERM SIGQUIT
 
-  cp -a "$from" "$to"
+  if [ -d "$from" ]; then
+    cp -a "${from}/." "$to" # copy as folder
+  else
+    cp -a "$from" "$to"
+  fi
 
   release_lock "${from}"
 }

--- a/backends/cache_fs
+++ b/backends/cache_fs
@@ -17,15 +17,24 @@ DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 restore_cache() {
   local from="${CACHE_FOLDER}/$1"
   local to="$2"
+  local fs_copy_tool="$3"
 
   wait_and_lock "${from}"
   # shellcheck disable=2064  # actually want variable interpolated here
   trap "release_lock_folder '${from}'" SIGINT SIGTERM SIGQUIT
 
   if [ -d "$from" ]; then
-    cp -a "${from}/." "$to" # copy as folder
+    if [ "$fs_copy_tool" = "rsync" ]; then
+      rsync -a --delete "${from}/." "$to" # copy as folder
+    else
+      cp -a "${from}/." "$to" # copy as folder
+    fi
   else
-    cp -a "$from" "$to"
+    if [ "$fs_copy_tool" = "rsync" ]; then
+      rsync -a --delete "$from" "$to"
+    else
+      cp -a "$from" "$to"
+    fi
   fi
 
   release_lock "${from}"

--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -30,6 +30,12 @@ if ! validate_compression "${COMPRESS}"; then
   exit 1
 fi
 
+FS_COPY_TOOL=$(plugin_read_config FS_COPY_TOOL 'cp')
+if ! validate_fs_copy_tool "${FS_COPY_TOOL}"; then
+  echo "+++ 🚨 Invalid value for fs_copy_tool option"
+  exit 1
+fi
+
 build_key "${MAX_LEVEL}" "${RESTORE_PATH}" >/dev/null # to validate the level
 
 SORTED_LEVELS=(file step branch pipeline all)
@@ -45,10 +51,10 @@ for CURRENT_LEVEL in "${SORTED_LEVELS[@]}"; do
 
     if compression_active; then
       TEMP_PATH=$(mktemp)
-      backend_exec get "${KEY}" "${TEMP_PATH}"
+      backend_exec get "${KEY}" "${TEMP_PATH}" "cp"
       uncompress "${TEMP_PATH}" "${RESTORE_PATH}"
     else
-      backend_exec get "${KEY}" "${RESTORE_PATH}"
+      backend_exec get "${KEY}" "${RESTORE_PATH}" "${FS_COPY_TOOL}"
     fi
 
     exit 0

--- a/lib/plugin.bash
+++ b/lib/plugin.bash
@@ -60,3 +60,16 @@ function plugin_read_config() {
   local default="${2:-}"
   echo "${!var:-$default}"
 }
+
+function validate_fs_copy_tool() {
+  local FS_COPY_TOOL="$1"
+
+  VALID_FS_COPY_TOOL=(cp rsync)
+  for VALID in "${VALID_FS_COPY_TOOL[@]}"; do
+    if [ "${FS_COPY_TOOL}" = "${VALID}" ]; then
+      return 0
+    fi
+  done
+
+  return 1
+}

--- a/plugin.yml
+++ b/plugin.yml
@@ -35,6 +35,11 @@ configuration:
         - type: array
           items:
             $ref: '#/$defs/valid_levels'
+    fs_copy_tool:
+      type: string
+      enum:
+        - cp
+        - rsync
   additionalProperties: false
   anyOf:
     - required: [ path, save ]


### PR DESCRIPTION
`rsync` is much more performant than `cp` as a means to sync directories, as it will do checks and avoid copying files that already exist in the folder and have the same content.

This reduces reusing a folder copy time from `30s` to `1s`!