### PR TITLE
Save logic updates

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -27,28 +27,38 @@ if ! validate_compression "${COMPRESS}"; then
   exit 1
 fi
 
-SAVE_LEVELS=()
-if plugin_read_list_into_result SAVE; then
-  for LEVEL in "${result[@]}"; do
-    SAVE_LEVELS+=("${LEVEL}")
-
-    # this validates the level as well
-    KEY=$(build_key "${LEVEL}" "${CACHE_PATH}" "${COMPRESS}")
-
-    if [ "${LEVEL}" = 'file' ] && [ -z "$(plugin_read_config MANIFEST)" ]; then
-      echo "+++ 🚨 Missing manifest option in the cache plugin for file-level saving"
-      exit 1
-    fi
-  done
-else
+if ! plugin_read_list_into_result SAVE; then
   echo 'Cache not setup for saving'
   exit 0
+fi
+
+ORDERED_LEVELS=(file step branch pipeline all)
+SAVE_LEVELS=()
+
+# array intersection keeping the order of the first array
+for O_LEVEL in "${ORDERED_LEVELS[@]}"; do
+  for R_LEVEL in "${result[@]}"; do
+    if [ "${O_LEVEL}" = "${R_LEVEL}" ]; then
+      SAVE_LEVELS+=("${O_LEVEL}")
+    fi
+  done
+done
+
+if [ "${#SAVE_LEVELS[@]}" -ne "${#result[@]}" ]; then
+  echo 'Invalid levels in the save list'
+  exit 1
 fi
 
 ACTUAL_PATH="${CACHE_PATH}"
 
 for LEVEL in "${SAVE_LEVELS[@]}"; do
+  # this validates the level as well
   KEY=$(build_key "${LEVEL}" "${CACHE_PATH}" "${COMPRESS}")
+
+  if [ "${LEVEL}" = 'file' ] && [ -z "$(plugin_read_config MANIFEST)" ]; then
+    echo "+++ 🚨 Missing manifest option in the cache plugin for file-level saving"
+    exit 1
+  fi
 
   if [ "$(plugin_read_config FORCE 'false')" != 'false' ] ||
      [ "${lower_level_updated:-false}" = 'true' ] ||

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -51,6 +51,7 @@ for LEVEL in "${SAVE_LEVELS[@]}"; do
   KEY=$(build_key "${LEVEL}" "${CACHE_PATH}" "${COMPRESS}")
 
   if [ "$(plugin_read_config FORCE 'false')" != 'false' ] ||
+     [ "${lower_level_updated:-false}" = 'true' ] ||
      ! backend_exec exists "${KEY}"; then
     echo "Saving ${LEVEL}-level cache of ${CACHE_PATH}"
     if compression_active && [ "${already_compressed:-false}" = 'false' ]; then
@@ -59,6 +60,7 @@ for LEVEL in "${SAVE_LEVELS[@]}"; do
       already_compressed='true' # avoid re-compressing the files
     fi
     backend_exec save "${KEY}" "${ACTUAL_PATH}"
+    lower_level_updated='true' # to force saving higher levels
   else
     echo "Cache of ${LEVEL} already exists, skipping"
   fi

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -60,7 +60,7 @@ teardown() {
   run "$PWD/hooks/post-command"
 
   assert_failure
-  assert_output --partial 'Invalid cache level'
+  assert_output --partial 'Invalid levels in the save list'
 }
 
 @test "Invalid compression level fails" {
@@ -190,7 +190,7 @@ teardown() {
 
   assert_failure
 
-  assert_output --partial 'Invalid cache level unreal'
+  assert_output --partial 'Invalid levels in the save list'
   refute_output --partial 'Saving pipeline-level cache'
 }
 

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -208,3 +208,46 @@ teardown() {
 
   unstub cache_dummy
 }
+
+@test "Multiple level saving not forced" {
+  export BUILDKITE_PLUGIN_CACHE_FORCE=false
+
+  export BUILDKITE_PLUGIN_CACHE_SAVE_0=all
+  export BUILDKITE_PLUGIN_CACHE_SAVE_1=pipeline
+
+  stub cache_dummy \
+    "exists \* \* : exit 0" \
+    "exists \* \* : exit 1" \
+    "save \* \* : echo saving \$3 in \$2"
+
+  run "$PWD/hooks/post-command"
+
+  assert_success
+  assert_output --partial 'Saving all-level cache'
+  refute_output --partial 'Saving pipeline-level cache'
+
+  unstub cache_dummy
+}
+
+@test "Multiple level saving lower level change forces higher levels" {
+  export BUILDKITE_PLUGIN_CACHE_FORCE=false
+
+  export BUILDKITE_PLUGIN_CACHE_SAVE_0=all
+  export BUILDKITE_PLUGIN_CACHE_SAVE_1=pipeline
+  export BUILDKITE_PLUGIN_CACHE_SAVE_2=step
+
+  stub cache_dummy \
+    "exists \* \* : exit 0" \
+    "exists \* \* : exit 1" \
+    "save \* \* : echo saving \$3 in \$2" \
+    "save \* \* : echo saving \$3 in \$2"
+
+  run "$PWD/hooks/post-command"
+
+  assert_success
+  assert_output --partial 'Saving all-level cache'
+  assert_output --partial 'Saving pipeline-level cache'
+  refute_output --partial 'Saving step-level cache'
+
+  unstub cache_dummy
+}


### PR DESCRIPTION
When a cache is saved and multiple are specified, higher levels will get updated as well.

This uncovered a bug in which the order was not respected during saves (the one from the option was used instead).

Closes #79 