### PR TITLE
Copy instead of Move for zip files

### DIFF
--- a/compression/zip_wrapper
+++ b/compression/zip_wrapper
@@ -30,7 +30,7 @@ elif [ "${OPERATION}" = "decompress" ]; then
         mkdir -p "${RESTORE_DIR}"
         # shellcheck disable=SC2164 # we will exit anyway
         cd "${RESTORE_DIR}"
-        mv "${SOURCE}" "${RESTORE_DIR}/compressed.zip"
+        cp "${SOURCE}" "${RESTORE_DIR}/compressed.zip"
         unzip -o "compressed.zip"
         rm "compressed.zip"
       )

--- a/lib/compression.bash
+++ b/lib/compression.bash
@@ -84,7 +84,7 @@ uncompress() {
         mkdir -p "${RESTORE_DIR}"
         # shellcheck disable=SC2164 # we will exit anyway
         cd "${RESTORE_DIR}"
-        mv "${FILE}" "${RESTORE_DIR}/compressed.zip"
+        cp "${FILE}" "${RESTORE_DIR}/compressed.zip"
         unzip -o "compressed.zip"
         rm "compressed.zip"
       )


### PR DESCRIPTION
This PR changes the `mv` to a `cp` when working with `zip` files.

The other code paths for `tar` and for non-absolute paths, both don't remove the compressed file, yet the `zip` compression code path does, because it is moving -> renaming -> removing.
This PR aligns this code path to only remove the copied file and leave the original compressed file where it is.

This should work in tandem with https://github.com/buildkite-plugins/cache-buildkite-plugin/pull/94 to make sure compressed files are cleaned up.
