### PR TITLE
Correct bug with multiple manifest files

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -51,7 +51,7 @@ for LEVEL in "${SAVE_LEVELS[@]}"; do
   # this validates the level as well
   KEY=$(build_key "${LEVEL}" "${CACHE_PATH}" "${COMPRESS}")
 
-  if [ "${LEVEL}" = 'file' ] && [ -z "$(plugin_read_config MANIFEST)" ]; then
+  if [ "${LEVEL}" = 'file' ] && [ -z "$(plugin_read_list MANIFEST)" ]; then
     echo "+++ 🚨 Missing manifest option in the cache plugin for file-level saving"
     exit 1
   fi

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -19,7 +19,7 @@ MAX_LEVEL=$(plugin_read_config RESTORE 'no')
 if [ "${MAX_LEVEL}" = 'no' ]; then
   echo 'Cache not setup for restoring'
   exit 0
-elif [ "${MAX_LEVEL}" = 'file' ] && [ -z "$(plugin_read_config MANIFEST)" ]; then
+elif [ "${MAX_LEVEL}" = 'file' ] && [ -z "$(plugin_read_list MANIFEST)" ]; then
   echo "+++ 🚨 Missing manifest option in the cache plugin for file-level restore"
   exit 1
 fi


### PR DESCRIPTION
After #93 using multiple manifests wouldn't work because the hook code was only looking for the option as a string and not when it was a list.