### PR TITLE
Fix file level cache restore when using the list-version of the manifest option

### DIFF
--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -31,7 +31,7 @@ build_key "${MAX_LEVEL}" "${RESTORE_PATH}" >/dev/null # to validate the level
 SORTED_LEVELS=(file step branch pipeline all)
 
 for CURRENT_LEVEL in "${SORTED_LEVELS[@]}"; do
-  if [ "${CURRENT_LEVEL}" = 'file' ] && [ -z "$(plugin_read_config MANIFEST)" ]; then
+  if [ "${CURRENT_LEVEL}" = 'file' ] && [ -z "$(plugin_read_list MANIFEST)" ]; then
     continue
   fi
 


### PR DESCRIPTION
Replace plugin_read_config with plugin_read_list when reading the manifest in the pre-command hook. This ensures list-version of the option is fully supported.

Before this change the pre-command hook would complete with no error and no cache restoration for file level cache when a manifest list was used.

I've confirmed this fixes this issue on a test build.

fixes #109 
relates to #106