### PR TITLE
Cache path removal bug

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -74,7 +74,7 @@ done
 
 # remove temporary compressed artifacts
 if [ "$(plugin_read_config KEEP_COMPRESSED_ARTIFACTS 'false')" = 'false' ]; then
-  if compression_active && [ -e "${ACTUAL_PATH}" ]; then
+  if compression_active && [ "${already_compressed}" == 'true' ] && [ -e "${ACTUAL_PATH}" ]; then
     rm -rf "${ACTUAL_PATH}"
   fi
 fi


### PR DESCRIPTION
Corrects a bug which caused the cached path to be removed.

This ensures that the `rm` is only called when the `ACTUAL_PATH` variable is modified.

Closes #112 