### PR TITLE
fix: set default value for already_compressed variable

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -74,7 +74,7 @@ done
 
 # remove temporary compressed artifacts
 if [ "$(plugin_read_config KEEP_COMPRESSED_ARTIFACTS 'false')" = 'false' ]; then
-  if compression_active && [ "${already_compressed}" == 'true' ] && [ -e "${ACTUAL_PATH}" ]; then
+  if compression_active && [ "${already_compressed:-false}" == 'true' ] && [ -e "${ACTUAL_PATH}" ]; then
     rm -rf "${ACTUAL_PATH}"
   fi
 fi


### PR DESCRIPTION
When the cache file already exists and removing temporary compressed artifacts, the script was checking the value of the already_compressed variable without ensuring it had been initialized. This could cause failures when compression wasn't activated since the variable would be unset.

Added a default value of 'false' using parameter expansion to prevent "unbound variable" errors when the variable hasn't been explicitly set.

fixes #116