### PR TITLE
SUP-4087 - Add callout for plugin dependencies in plugin docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ steps:
           save: file
 ```
 
-### Dependencies
-The plugin supports various backends and compression algorithms, and some environments (such as docker containers based on Alpine Linux), may not have all of the dependencies needed to use the plugin out of the box. Ensure that the necessary dependencies are installed in the agent environment or container before using this plugin.
+## Dependencies
+The plugin supports various backends and compression algorithms, and some environments (such as Docker containers based on Alpine Linux), may not have all of the dependencies needed to use the plugin out of the box. Ensure that the necessary dependencies are installed in the agent environment or container before using this plugin.
 
 - `zstd` for zstd compression
 - `tar` for tar compression


### PR DESCRIPTION
The cache plugin makes use of a few dependencies (such as `zstd`, and the `aws cli`) which are not always going to be installed and available in a job's environment. A job running from a step as defined in Buildkite should have access to the dependencies required by that job (including plugins). 

This has been a bit of a sharp edge for some users who are running their jobs inside of containers based on minimal images like [alpine](https://hub.docker.com/_/alpine), or other restricted environments.

This PR aims to add a section to the plugin documentation around calling out the dependencies that may be required for certain functionality of the plugin to work as intended.

addresses #122 