### PR TITLE
fix(windows): handle Windows absolute cache paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ steps:
   - label: ':nodejs: Install dependencies'
     command: npm ci
     plugins:
-      - cache#v1.10.0:
+      - cache#v1.11.0:
           manifest: package-lock.json
           path: node_modules
           restore: file
@@ -85,7 +85,7 @@ steps:
   - label: ':nodejs: Install dependencies'
     command: npm ci
     plugins:
-      - cache#v1.10.0:
+      - cache#v1.11.0:
           backend: fs
           path: node_modules
           manifest: package-lock.json
@@ -124,7 +124,7 @@ steps:
     plugins:
       - aws-assume-role-with-web-identity#v1.4.0:
           role-arn: $AWS_ROLE_ARN
-      - cache#v1.10.0:
+      - cache#v1.11.0:
           backend: s3
           path: node_modules
           manifest: package-lock.json
@@ -156,7 +156,7 @@ steps:
   - label: ':nodejs: Install dependencies'
     command: npm ci
     plugins:
-      - cache#v1.10.0:
+      - cache#v1.11.0:
           backend: gcs
           path: node_modules
           manifest: package-lock.json
@@ -202,7 +202,7 @@ steps:
     secrets:
       - AZURE_STORAGE_KEY
     plugins:
-      - cache#v1.10.0:
+      - cache#v1.11.0:
           backend: azure
           path: node_modules
           manifest: package-lock.json
@@ -230,7 +230,7 @@ steps:
       - azure-login#v1.0.1:  # Authenticate with managed identity first
           use-identity: true
           client-id: your-managed-identity-client-id
-      - cache#v1.10.0:
+      - cache#v1.11.0:
           backend: azure
           path: node_modules
           manifest: package-lock.json
@@ -254,7 +254,7 @@ steps:
     secrets:
       - AZURE_STORAGE_CONNECTION_STRING
     plugins:
-      - cache#v1.10.0:
+      - cache#v1.11.0:
           backend: azure
           path: node_modules
           manifest: package-lock.json
@@ -278,7 +278,7 @@ steps:
     secrets:
       - AZURE_STORAGE_SAS_TOKEN
     plugins:
-      - cache#v1.10.0:
+      - cache#v1.11.0:
           backend: azure
           path: node_modules
           manifest: package-lock.json
@@ -340,7 +340,7 @@ steps:
       os: "{{matrix}}"
       GOMODCACHE: pkg/cache
     plugins:
-      - cache#v1.10.0:
+      - cache#v1.11.0:
           path: pkg/cache
           manifest:
             - go.mod
@@ -406,7 +406,7 @@ steps:
   - label: ':nodejs: Install dependencies'
     command: npm ci
     plugins:
-      - cache#v1.10.0:
+      - cache#v1.11.0:
           manifest:
             - package-lock.json
           path: node_modules
@@ -418,7 +418,7 @@ steps:
   - label: ':test_tube: Run tests'
     command: npm test # does not save cache, not necessary
     plugins:
-      - cache#v1.10.0:
+      - cache#v1.11.0:
           manifest:
             - package-lock.json
           path: node_modules
@@ -428,7 +428,7 @@ steps:
     if: build.branch == "master"
     command: npm run deploy
     plugins:
-      - cache#v1.10.0:
+      - cache#v1.11.0:
           manifest:
             - package-lock.json
           path: node_modules
@@ -453,7 +453,7 @@ steps:
   - label: ':nodejs: Install dependencies'
     command: npm ci
     plugins:
-      - cache#v1.10.0:
+      - cache#v1.11.0:
           path: node_modules
           manifest: package-lock.json
           restore: file

--- a/compression/tgz_wrapper
+++ b/compression/tgz_wrapper
@@ -6,7 +6,11 @@ SOURCE=${2?Source not specified}
 TARGET=${3?Target not specified}
 
 is_absolute_path() {
-  [ "${1:0:1}" = "/" ]
+  case "$1" in
+    /*) return 0 ;;
+    [A-Za-z]:[\\/]*) return 0 ;;
+    *) return 1 ;;
+  esac
 }
 
 if [ "${OPERATION}" = "compress" ]; then

--- a/compression/zip_wrapper
+++ b/compression/zip_wrapper
@@ -6,7 +6,11 @@ SOURCE=${2?Source not specified}
 TARGET=${3?Target not specified}
 
 is_absolute_path() {
-  [ "${1:0:1}" = "/" ]
+  case "$1" in
+    /*) return 0 ;;
+    [A-Za-z]:[\\/]*) return 0 ;;
+    *) return 1 ;;
+  esac
 }
 
 if [ "${OPERATION}" = "compress" ]; then

--- a/compression/zstd_wrapper
+++ b/compression/zstd_wrapper
@@ -6,7 +6,11 @@ SOURCE=${2?Source not specified}
 TARGET=${3?Target not specified}
 
 is_absolute_path() {
-  [ "${1:0:1}" = "/" ]
+  case "$1" in
+    /*) return 0 ;;
+    [A-Za-z]:[\\/]*) return 0 ;;
+    *) return 1 ;;
+  esac
 }
 
 # Determine how to use zstd compression

--- a/tests/compression.bats
+++ b/tests/compression.bats
@@ -164,3 +164,68 @@ setup() {
 
   unstub tar
 }
+
+@test 'zstd_wrapper treats Windows drive paths as absolute' {
+  stub tar \
+    "--help : echo '--zstd'" \
+    "-c --zstd -P -f archive.tzst C:/cache/foo : echo compressed windows absolute" \
+    "--help : echo '--zstd'" \
+    "-x --zstd -P -f archive.tzst C:/cache/foo : echo decompressed windows absolute"
+
+  run "${PWD}/compression/zstd_wrapper" compress "C:/cache/foo" archive.tzst
+  assert_success
+  assert_output --partial "compressed windows absolute"
+
+  run "${PWD}/compression/zstd_wrapper" decompress archive.tzst "C:/cache/foo"
+  assert_success
+  assert_output --partial "decompressed windows absolute"
+
+  unstub tar
+}
+
+@test 'tgz_wrapper treats Windows drive paths as absolute' {
+  stub tar \
+    "czPf archive.tgz C:/cache/foo : echo compressed windows absolute" \
+    "xzPf archive.tgz C:/cache/foo : echo decompressed windows absolute"
+
+  run "${PWD}/compression/tgz_wrapper" compress "C:/cache/foo" archive.tgz
+  assert_success
+  assert_output --partial "compressed windows absolute"
+
+  run "${PWD}/compression/tgz_wrapper" decompress archive.tgz "C:/cache/foo"
+  assert_success
+  assert_output --partial "decompressed windows absolute"
+
+  unstub tar
+}
+
+@test 'zip_wrapper treats Windows drive paths as absolute' {
+  cd "${BATS_TEST_TMPDIR}"
+  mkdir -p "C:/cache"
+
+  stub zip \
+    "-r ${BATS_TEST_TMPDIR}/archive.zip C:/cache/foo : echo compressed windows absolute"
+  stub mv \
+    "${BATS_TEST_TMPDIR}/archive.zip ${BATS_TEST_TMPDIR}/archive : echo moved compressed archive"
+  stub cp \
+    "${BATS_TEST_TMPDIR}/archive C:/cache/compressed.zip : echo copied archive for windows absolute restore"
+  stub unzip \
+    "-o compressed.zip : echo decompressed windows absolute"
+  stub rm \
+    "compressed.zip : echo removed temporary zip"
+
+  run "${OLDPWD}/compression/zip_wrapper" compress "C:/cache/foo" "${BATS_TEST_TMPDIR}/archive"
+  assert_success
+  assert_output --partial "compressed windows absolute"
+
+  touch "${BATS_TEST_TMPDIR}/archive"
+  run "${OLDPWD}/compression/zip_wrapper" decompress "${BATS_TEST_TMPDIR}/archive" "C:/cache/foo"
+  assert_success
+  assert_output --partial "decompressed windows absolute"
+
+  unstub rm
+  unstub unzip
+  unstub cp
+  unstub mv
+  unstub zip
+}


### PR DESCRIPTION
## Description

Fixes cache restore failures for Windows drive-letter absolute paths like `C:/cache/foo` and `C:\cache\foo`.

The compression wrappers now detect Windows absolute paths in addition to POSIX `/...` paths, ensuring `zstd`, `tgz`, and `zip` compression/restore paths handle them consistently. Added regression coverage for all three wrappers.

## Context

Fixes https://github.com/buildkite-plugins/cache-buildkite-plugin/issues/154

## Tests

Tested with:

```sh
docker run --rm -v "${PWD}":/plugin buildkite/plugin-tester:latest
```
